### PR TITLE
Transplant surgery

### DIFF
--- a/Content.Server/Palmtree/Surgery/Components/ValidSurgeryToolComponent.cs
+++ b/Content.Server/Palmtree/Surgery/Components/ValidSurgeryToolComponent.cs
@@ -10,6 +10,10 @@ namespace Content.Server.Palmtree.Surgery
         [ViewVariables(VVAccess.ReadWrite)]
         public string kind = "scalpel";
 
+        [DataField("subKind")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public string subKind = "none"; // Used for implants
+
         [DataField("useDelay")]
         [ViewVariables(VVAccess.ReadWrite)]
         public float useDelay = 3.0f;
@@ -29,5 +33,9 @@ namespace Content.Server.Palmtree.Surgery
         [DataField("audioEnd")]
         [ViewVariables(VVAccess.ReadWrite)]
         public SoundSpecifier? audioEnd = null;
+
+        [DataField("consumedOnUse")] // Used for implants
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool consumedOnUse = false;
     }
 }

--- a/Content.Shared/Atmos/Rotting/RottingComponent.cs
+++ b/Content.Shared/Atmos/Rotting/RottingComponent.cs
@@ -41,12 +41,13 @@ public sealed partial class RottingComponent : Component
     /// The damage dealt by rotting.
     /// </summary>
     [DataField]
-    public DamageSpecifier Damage = new()
+    public DamageSpecifier Damage = new() // SYNDIE STATION CHANGE START
     {
         DamageDict = new()
         {
-            { "Blunt", 0.06 },
-            { "Cellular", 0.06 }
+            { "Poison", 0.15 },
+            { "Asphyxiation", 0.15 },
+            { "Radiation", -10 }
         }
-    };
+    }; // SYNDIE STATION CHANGE END
 }

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -12,7 +12,6 @@
       - id: Cautery
       - id: Retractor
       - id: Scalpel
-      - id: SurgeryItemBloodFilter # Syndie change
       - id: PhantomLinkCard # Syndie change
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -68,7 +68,6 @@
       - id: Saw
       - id: Hemostat
       - id: ClothingMaskSterile
-      - id: SurgeryItemBloodFilter # Syndie change
       - id: PhantomLinkCard # Syndie change
 
 - type: entity

--- a/Resources/Prototypes/Palmtree/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Palmtree/Catalog/Cargo/cargo_medical.yml
@@ -1,0 +1,39 @@
+- type: cargoProduct
+  id: SurgeryCrate
+  icon:
+    sprite: Objects/Specific/Medical/Surgery/scalpel.rsi
+    state: scalpel
+  product: CrateMedicalSurgery
+  cost: 1500
+  category: cargoproduct-category-name-medical
+  group: market
+
+# I'm gonna make a proper file for this later, I just wanna get it done now.
+- type: entity
+  id: CrateMedicalSpareOrgans
+  parent: CrateSurgery
+  name: Spare organs crate
+  description: A crate containing 3 of each kind of Syndicate-produced bio-synthetic universal organs as well as a spare phantom link.
+  components:
+  - type: StorageFill
+    contents:
+      - id: BioSynthHeart
+      - id: BioSynthHeart
+      - id: BioSynthHeart
+      - id: BioSynthLiver
+      - id: BioSynthLiver
+      - id: BioSynthLiver
+      - id: BioSynthLungs
+      - id: BioSynthLungs
+      - id: BioSynthLungs
+      - id: PhantomLinkCard
+
+- type: cargoProduct
+  id: SpareOrganCrate
+  icon:
+    sprite: Mobs/Species/Human/organs.rsi
+    state: heart-on
+  product: CrateMedicalSpareOrgans
+  cost: 2000
+  category: cargoproduct-category-name-medical
+  group: market

--- a/Resources/Prototypes/Palmtree/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Palmtree/Entities/Objects/Specific/Medical/surgery.yml
@@ -48,8 +48,6 @@
     tags:
       - SurgeryTool
 
-# Placeholder PAIs, aka semi-automatic ghost roles
-
 - type: entity
   parent: BaseItem
   id: PhantomLinkCard
@@ -71,3 +69,80 @@
       shader: unshaded
       map: ["screen"]
   - type: BlockMovement
+
+# ORGANS
+
+- type: entity
+  parent: BaseItem
+  id: BioSyntheticOrgan
+  abstract: true
+  components:
+  - type: PSurgeryTool
+    consumedOnUse: true
+    kind: Implant
+    useDelay: 5
+    damageOnUse:
+      types:
+        Asphyxiation: -1 # I cannot leave this empty or else the server crashes
+    audioStart:
+      path: "/Audio/Palmtree/Items/Medical/organ1.ogg"
+    audioEnd:
+      path: "/Audio/Palmtree/Items/Medical/organ2.ogg"
+  - type: Item
+    size: Tiny
+  - type: Sprite
+    sprite: Mobs/Species/Human/organs.rsi
+
+- type: entity
+  parent: BioSyntheticOrgan
+  id: BioSynthHeart
+  name: bio-synthetic heart
+  description: This heart can be transplanted into any living organism and it will adapt to it's organism, in this state it is currently in stasis. Implanting this will allow the patient to be shocked even after rotting for long.
+  components:
+  - type: Sprite
+    state: heart-on
+  - type: PSurgeryTool
+    subKind: BioHeart
+
+- type: entity
+  parent: BioSyntheticOrgan
+  id: BioSynthLiver
+  name: bio-synthetic liver
+  description: This liver can be transplanted into any living organism and it will adapt to it's organism, in this state it is currently in stasis. Implanting this will allow the patient to be revived even after building up too much toxin in their body, and in case of rot this might be necessary for revival.
+  components:
+  - type: Sprite
+    state: liver
+  - type: PSurgeryTool
+    subKind: BioLiver
+    damageOnUse:
+      types:
+        Poison: -2147483648 # Literally the max 32 bit value, if your patient has gone higher than this, maybe it's time to restart the round.
+
+- type: entity
+  parent: BioSyntheticOrgan
+  id: BioSynthLungs
+  name: bio-synthetic lungs
+  description: This pair of lungs can be transplanted into any living organism and it will adapt to it's organism, in this state it is currently in stasis. Implanting this will help with excessive asphyxiation, and in case of rot this might be necessary for revival.
+  components:
+  - type: Sprite
+    layers:
+      - state: lung-l
+      - state: lung-r
+  - type: PSurgeryTool
+    subKind: BioLungs
+    damageOnUse:
+      types:
+        Asphyxiation: -2147483648 # Literally the max 32 bit value, if your patient has gone higher than this, maybe it's time to restart the round.
+
+- type: entity
+  parent: BioSyntheticOrgan
+  id: BioSynthEyes
+  name: bio-synthetic eyes
+  description: This pair of eyes can be transplanted into any living organism and it will adapt to it's organism, in this state it is currently in stasis. Implanting this will treat the patient's blindness and serves as an alternative to oculine.
+  components:
+  - type: Sprite
+    layers:
+      - state: eyeball-l
+      - state: eyeball-r
+  - type: PSurgeryTool
+    subKind: BioEyes


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This update is the beginning of the implants system as well as a placeholder for organ manipulation, the contents of this PR in itself might be enough to change how medical is played a little so it's important even non-coders give it a read.

Transplants can be done with bio-synthetic organs at the moment (and exclusively only them) with the following procedure:

Scalpel -> Retractor -> Saw

Transplanting on the dead has a few new effects, transplanting a new heart onto someone that is dead resets their rotting and prevents them from starting to rot again. (This property is removed once the person is revived, and if they die they will begin to rot again)

Transplanting a new pair of lungs completely resets asphyxiation and transplanting a new liver completely resets poison.

Why would you do these though when chems exist? Glad you asked, now when you rot you start taking organ damage, which manifests itself into giving the dead even more poison or asphyxiation, meaning that if you leave a body to rot for too long, it will not only need a new heart, but also new liver and lungs.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Organ transplating
- tweak: Made rot no longer give cellular damage
- tweak: Made rot deal asphyixation and poison damage
- tweak: Made rot heal radiation
- remove: Blood filter
