### PR TITLE
Surgery condition rework + guidebook entry

### DIFF
--- a/Resources/Prototypes/Guidebook/medical.yml
+++ b/Resources/Prototypes/Guidebook/medical.yml
@@ -7,6 +7,7 @@
   - Chemist
   - Cloning
   - Cryogenics
+  - Surgery # Syndicate change
 
 - type: guideEntry
   id: Medical Doctor
@@ -48,3 +49,9 @@
   id: AdvancedBrute
   name: guide-entry-brute
   text: "/ServerInfo/Guidebook/Medical/AdvancedBrute.xml"
+# Syndicate change start
+- type: guideEntry
+  id: Surgery
+  name: Surgery
+  text: "/ServerInfo/Palmtree/Medical/Surgery.xml"
+# Syndicate change end

--- a/Resources/ServerInfo/Palmtree/Medical/Surgery.xml
+++ b/Resources/ServerInfo/Palmtree/Medical/Surgery.xml
@@ -23,7 +23,7 @@ Every procedure starts with an incision and ends with cauterization, if you scre
 <GuideEntityEmbed Entity="Cautery" Caption="cauterization"/>
 
 ## Procedure conditions
-Performing procedures makes each step get progressively slower, the worst case scenario is if you were to do surgery on yourself while standing up and awake, and the best case scenario would be if you were doing surgery on someone else while they are laying down and sedated.
+Poor condition modifiers stacks and makes each step get progressively slower, the worst case scenario is if you were to do surgery on yourself while standing up and awake, and the best case scenario would be if you were doing surgery on someone else while they are laying down and sedated.
 
 You also need to undress people before performing surgery.
 

--- a/Resources/ServerInfo/Palmtree/Medical/Surgery.xml
+++ b/Resources/ServerInfo/Palmtree/Medical/Surgery.xml
@@ -1,0 +1,48 @@
+<Document>
+# Surgery
+Let's say that whatever patient arrives from the station straight into medbay is in a really bad shape. You have several options, clone them if they're dead, apply a mix of chemicals, topical medicine or even use the cryo tube with cryoxadone. There is a downside to those options however, all of them require specific external resources that aren't exactly abundant and a constantly running power supply.
+
+That's where surgery comes in, it will allow you to treat the basic damages of your patients easily (albeit not as effective as every other method above) and it will even allow you to bring people who have rotted for long periods of time back to life.
+
+<Box>
+<GuideEntityEmbed Entity="Cautery"/>
+<GuideEntityEmbed Entity="Drill"/>
+<GuideEntityEmbed Entity="Scalpel"/>
+<GuideEntityEmbed Entity="Retractor"/>
+<GuideEntityEmbed Entity="Hemostat"/>
+<GuideEntityEmbed Entity="Saw"/>
+</Box>
+
+## The Basics
+Performing surgery is done by steps, some steps are static while others are interchangeable, meaning they can be done alongside a more advanced procedure.
+
+Every procedure starts with an incision and ends with cauterization, if you screw up at any point you can cauterize the patient and try again. The most basic procedure is tend wounds, it is done by using a hemostat at any point during the surgery, doing so also clamps the bleeders to stop your patient from bleeding out.
+
+<GuideEntityEmbed Entity="Scalpel" Caption="incision"/>
+<GuideEntityEmbed Entity="Hemostat" Caption="tend wounds (repeatable)"/>
+<GuideEntityEmbed Entity="Cautery" Caption="cauterization"/>
+
+## Procedure conditions
+Performing procedures makes each step get progressively slower, the worst case scenario is if you were to do surgery on yourself while standing up and awake, and the best case scenario would be if you were doing surgery on someone else while they are laying down and sedated.
+
+You also need to undress people before performing surgery.
+
+## Transplants
+If someone dies and doesn't get revived in time, their heart rot and soon does the rest of their organs, which get manifested in different types of damages (asphyxiation for lungs and poison for liver), lucky you, you should be prepared by now to deal exactly with that, these sorts of procedures should be done in this exact order, and the only tool you may optionally use during it is the hemostat to stop the patient from bleeding if they start to.
+
+In other words, if you can't shock someone due to rot you give them a new heart, if you can't shock someone due to excessive asphyxiation give them new lungs and if you can't shock someone because of poison give them a new liver.
+
+<GuideEntityEmbed Entity="Scalpel" Caption="incision"/>
+<GuideEntityEmbed Entity="Retractor" Caption="retract skin"/>
+<GuideEntityEmbed Entity="Saw" Caption="saw bones"/>
+<GuideEntityEmbed Entity="BioSynthLiver" Caption="implant organ"/>
+<GuideEntityEmbed Entity="Cautery" Caption="cauterization"/>
+
+Additionally, you can also use the phantomlink card instead of an organ during that step to transfer someone's mind from and into the body being operated. The phantomlink can also be inserted in borgs!
+
+<GuideEntityEmbed Entity="PhantomLinkCard" Caption="the phantomlink (sprite is a placeholder)"/>
+
+## Getting organs
+Currently the only transplantable organs are Interdyne's bio-synthetic organs, you can get them by buying a crate of them at cargo.
+
+</Document>


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Instead of completely barring you from doing surgery, now you can do surgery on people standing, awake and such, even on yourself, but it now adds to an "improper condition" score, which increases the time for each step.

Sawing yourself while laying down will take roughly for example, 25 seconds because it's you, adding a 3 to the score, and you're awake, adding an 1.

The setup is now completely optional and it makes surgery quicker, the only required part currently is undressing the patient (remove jumpsuit and outer clothing)

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Improper surgery now doesn't outright stop you from performing the steps, but it's worse to do it that way.
